### PR TITLE
Use terrestrial time for access calculation only

### DIFF
--- a/missioncontrol/home/models.py
+++ b/missioncontrol/home/models.py
@@ -20,8 +20,6 @@ from django.utils import timezone, dateformat
 from pytz import UTC
 from skyfield.api import Topos, EarthSatellite
 
-from v0.time import iso, utc
-
 GS_RESET_TIME_S = 90  # FIXME this is a wag
 
 logger = logging.getLogger(__name__)
@@ -459,7 +457,7 @@ class CachedAccess(models.Model):
         }
 
     def to_access(self, base_url=''):
-        return Access(utc(self.start_time), utc(self.end_time),
+        return Access(self.start_time, self.end_time,
                       self.satellite, self.groundstation,
                       self.max_alt, base_url=base_url)
 

--- a/missioncontrol/tests/test_access_id.py
+++ b/missioncontrol/tests/test_access_id.py
@@ -3,7 +3,7 @@ import pytest
 
 from skyfield.api import Loader
 from django.conf import settings
-from v0.accesses import Access
+from v0.accesses import Access, filter_range
 
 load = Loader(settings.EPHEM_DIR)
 timescale = load.timescale()
@@ -15,4 +15,32 @@ def test_access_id_roundtrip():
     time = timescale.utc(2018, 5, 23, 1, 2, 3)
     accid = Access.encode_access_id(sat_id, gs_id, time)
     assert (sat_id, gs_id, time) == Access.decode_access_id(accid)
+
+
+class Window(object):
+    ts = load.timescale()
+
+    def __init__(self, start_time, end_time):
+        self.start_time = self.ts.utc(start_time)
+        self.end_time = self.ts.utc(end_time)
+
+windows = [
+    Window(2018, 2019),
+    Window(2019, 2020),
+    Window(2020, 2021),
+    Window(2021, 2022)
+]
+
+@pytest.mark.parametrize("windows,range_inclusive,expected", [
+    (windows, "both", windows),
+    (windows, "start", windows[:-1]),
+    (windows, "end", windows[1:]),
+    (windows, "neither", windows[1:-1])
+])
+def test_filter_range_inclusive_both(windows, range_inclusive, expected):
+    ts = load.timescale()
+    range_start = ts.utc(2019)
+    range_end = ts.utc(2021)
+    filtered = list(filter_range(windows, range_start, range_end, range_inclusive))
+    assert filtered == expected
 

--- a/missioncontrol/tests/test_time.py
+++ b/missioncontrol/tests/test_time.py
@@ -1,35 +1,21 @@
 import json
 import pytest
+import datetime
+import pytz
 from skyfield.api import Loader
 from django.conf import settings
 
-load = Loader(settings.EPHEM_DIR)
+from v0.time import utc
 
-from v0.time import filter_range
 
-class Window(object):
-    ts = load.timescale()
+def test_bad_datetime():
+    est = pytz.timezone('US/Eastern')
+    dt = datetime.datetime.utcnow()
+    dt = est.localize(dt)
+    with pytest.raises(ValueError):
+        utc(dt)
 
-    def __init__(self, start_time, end_time):
-        self.start_time = self.ts.utc(start_time)
-        self.end_time = self.ts.utc(end_time)
 
-windows = [
-    Window(2018, 2019),
-    Window(2019, 2020),
-    Window(2020, 2021),
-    Window(2021, 2022)
-]
-
-@pytest.mark.parametrize("windows,range_inclusive,expected", [
-    (windows, "both", windows),
-    (windows, "start", windows[:-1]),
-    (windows, "end", windows[1:]),
-    (windows, "neither", windows[1:-1])
-])
-def test_filter_range_inclusive_both(windows, range_inclusive, expected):
-    ts = load.timescale()
-    range_start = ts.utc(2019)
-    range_end = ts.utc(2021)
-    filtered = list(filter_range(windows, range_start, range_end, range_inclusive))
-    assert filtered == expected
+def test_bad_isostring():
+    with pytest.raises(ValueError):
+        d = utc("2018-05-23T00:00:00+13:00")

--- a/missioncontrol/v0/time.py
+++ b/missioncontrol/v0/time.py
@@ -1,115 +1,31 @@
-from astropy.time import Time
+from copy import copy
 from datetime import datetime
-from django.conf import settings
-from skyfield.api import Loader
-
-load = Loader(settings.EPHEM_DIR)
-
-TWO_DAYS_S = 2 * 24 * 60 * 60
+from pytz import UTC
+from dateutil.parser import parse
+from dateutil.tz import tzutc
+from skyfield.api import Time
 
 
-def timescale_functions():
-    """ skyfield requires a "timescale" object that is used for things like
-        leap seconds. we want to initialize it once, but avoid making it
-        a global variable.
-        This closure exposes two functions that rely on a global timescale,
-        now : returns a Time() of the current time
-        add_seconds : returns a Time() with s seconds added
+def utc(t):
+    """ do whatever it takes to make time into datetime
     """
-    timescale = load.timescale()
+    # get datetime
+    if isinstance(t, datetime):
+        pass
+    elif t == "now":
+        t = datetime.utcnow()
+    elif isinstance(t, str):
+        t = parse(t)
+    elif isinstance(t, tuple):
+        t = datetime(*t)
+    elif isinstance(t, Time):
+        t = t.utc_datetime()
 
-    def now():
-        return timescale.now()
+    # ensure UTC
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=UTC)
+    if t.tzname() != 'UTC':
+        raise ValueError(
+            f"Non-UTC timezones ({t}, {t.tzname()}) are not supported.")
 
-    def add_seconds(t, s):
-        """
-        There's no easier way to add seconds to a Time object :(
-        """
-        return timescale.utc(*map(sum, zip(t.utc, (0, 0, 0, 0, 0, s))))
-
-    def utc(t):
-        """ do whatever it takes to make time into skyfield
-        """
-        if t == "now":
-            return now()
-        if isinstance(t, str):
-            t = timescale.from_astropy(Time(t, format='isot'))
-        if isinstance(t, tuple):
-            t = timescale.utc(*t)
-        if isinstance(t, datetime):
-            t = timescale.utc(t)
-        return t
-    
-    def iso(t):
-        t = utc(t)
-        return t.utc_iso(places=6)
-    
-    def midpoint(start_time, end_time):
-        start_time = utc(start_time)
-        end_time = utc(end_time)
-        mid_time = timescale.tai_jd(
-            ((start_time.tai + end_time.tai) / 2)
-        )
-        return mid_time
-
-    return add_seconds, now, utc, iso, midpoint
-
-
-add_seconds, now, utc, iso, midpoint = timescale_functions()
-
-
-def make_timeseries(start, end, step):
-    """ return a list of times from start to end.
-        each step is 'step' seconds after the previous time.
-    """
-    if end.tt < start.tt:
-        raise RuntimeError("end cannot be before start")
-
-    t = start
-    ts = [t]
-    while t.tt <= end.tt:
-        t = add_seconds(t, step)
-        ts += [t]
-    return ts
-
-
-def get_default_range(range_start=None, range_end=None):
-    """ cast to internal time, set default range_start and range_end times
-    """
-    if range_start is None:
-        range_start = now()
-    else:
-        range_start = utc(range_start)
-    if range_end is None:
-        range_end = add_seconds(range_start, TWO_DAYS_S)
-    else:
-        range_end = utc(range_end)
-
-    return range_start, range_end
-
-
-def filter_range(windows, range_start, range_end, range_inclusive):
-    """ given a list of time windows (object that have start and end times),
-        filters out items base on the range_inclusive criteria:
-          start - the start of the range is inclusive
-          end - the end of the range is inclusive
-          neither - all windows must fit completely within range
-          both (default) - windows that overlap with range are returned
-
-        this is useful for pagination, when you may want to set either end to
-        inclusive depending on the direction of the page so as to not get
-        duplicate items.
-    """
-    # filter the start of the range
-    if range_inclusive in ['end', 'neither']:
-        windows = filter(lambda w: utc(w.start_time).tt >= range_start.tt, windows)
-    else:
-        windows = filter(lambda w: utc(w.end_time).tt >= range_start.tt, windows)
-
-    # filter the end of the range
-    if range_inclusive in ['start', 'neither']:
-        windows = filter(lambda w: utc(w.end_time).tt <= range_end.tt, windows)
-    else:
-        windows = filter(lambda w: utc(w.start_time).tt <= range_end.tt, windows)
-
-    return windows
+    return t


### PR DESCRIPTION
Otherwise use datetime for full microsecond precision.

Why is this necessary?
We don't actually care about a microsecond here or there (in terms of orbital precision), _but_ when we create an object in MC with an iso8601 time, we want to be able to find that object again.

If we create an pass with a start, say `2018-05-23T00:00:00.123456Z` and then we search for it with  `range_start=2018-05-23T00:00:00.123456Z`, but the conversion to terrestrial time changes the range_start to  `2018-05-23T00:00:00.123466Z`, the minor loss in precision means we won't find the object we expect to (sometimes..).

This diff cordons off the use of skyfield `Time`s to just the accesses file, relying on datetime elsewhere.