### PR TITLE
Pass locking

### DIFF
--- a/missioncontrol/tests/utils.py
+++ b/missioncontrol/tests/utils.py
@@ -1,0 +1,30 @@
+import threading
+
+def concurrent_test(testtimes):
+    """
+    Add this decorator to small pieces of code that you want to test
+    concurrently to make sure they don't raise exceptions when run at the
+    same time.  E.g., some Django views that do a SELECT and then a subsequent
+    INSERT might fail when the INSERT assumes that the data has not changed
+    since the SELECT.
+    """
+    def test_concurrently_decorator(test_func):
+        def wrapper(*args, **kwargs):
+            exceptions = []
+            def call_test_func():
+                try:
+                    test_func(*args, **kwargs)
+                except Exception as e:
+                    exceptions.append(e)
+                    raise
+            threads = []
+            for i in range(testtimes):
+                threads.append(threading.Thread(target=call_test_func))
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            if exceptions:
+                raise Exception('test_concurrently intercepted %s exceptions: %s' % (len(exceptions), exceptions))
+        return wrapper
+    return test_concurrently_decorator


### PR DESCRIPTION
Without pass locking it's possible for two concurrent `Pass` updates to end up conflicting with each other, if the `clean` check passes on both before the inserts are complete.

This instead adds a lock around the entire `save` of the `Pass` object, so only one `Pass.save` call can be active at once (by locking the postgresql table)