### PR TITLE
Add a description to access PUT requestBody.

### DIFF
--- a/missioncontrol/openapi/openapi.yaml
+++ b/missioncontrol/openapi/openapi.yaml
@@ -567,6 +567,7 @@ paths:
            type: string
            format: uuid
       requestBody:
+        description: "Use **either** an `access_id` or all of `satellite` `groundstation` `start_time` and `end_time` to specify the Pass."
         content:
           application/json:
             schema:


### PR DESCRIPTION
Currently swaggerUI doesn't show any indication of 'oneOf' or 'allOf' in
the UI. So add some helpful text for now.